### PR TITLE
Update redirect from 2025 to 2026 in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,6 @@ TZ = "Europe/Amsterdam"
 
 [[redirects]]
     from = "/"
-    to = "/2025/"
+    to = "/2026/"
     status = 302
     force = true 


### PR DESCRIPTION
This pull request updates the default redirect for the root URL in the `netlify.toml` configuration file to point to `/2026/` instead of `/2025/`. This ensures users visiting the site are redirected to the correct year.

* Updated the root URL redirect in `netlify.toml` to point to `/2026/` instead of `/2025/`.