### PR TITLE
Hide technical program menu until we're ready to put out a call for papers

### DIFF
--- a/content/2026/_index.md
+++ b/content/2026/_index.md
@@ -15,9 +15,9 @@ layout: home
 ## August 31–September 4, 2026
 ## Welcome to Sherbrooke, Québec, Canada!
 
-{{< button-link label="Call For Papers"
+<!-- {{< button-link label="Call For Papers"
                 url="call"
-                icon="cfp" >}}
+                icon="cfp" >}} -->
 
 {{% /jumbo %}}
 

--- a/content/2026/call.md
+++ b/content/2026/call.md
@@ -1,7 +1,7 @@
 ---
 title: Call for papers
 year: 2026
-draft: false
+draft: true
 type: text_page
 menu:
     2026:

--- a/hugo.toml
+++ b/hugo.toml
@@ -170,10 +170,10 @@ unsafe = true
     weight = 10
     identifier = "home"
     pageRef = '/2026'
-  [[menu.2026]]
-    name = "Technical Program"
-    weight = 20
-    identifier = "technical-program"
+#  [[menu.2026]]
+#    name = "Technical Program"
+#    weight = 20
+#    identifier = "technical-program"
   [[menu.2026]]
     name = "Attend"
     weight = 30


### PR DESCRIPTION
This was done on the QIP website last year, I believe; and I think that makes sense, it's cleaner than having a CFP link that just leads to an "under construction" page.