### PR TITLE
Extend On-time bird registration to August 12 (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ public
 # Local Netlify folder
 .netlify
 .idea
+.claude
+__pycache__
 posters_bak.json
 QCrypt_background1old.png
 letter.aux

--- a/content/2026/_index.md
+++ b/content/2026/_index.md
@@ -60,8 +60,8 @@ See the list of previous conferences <a style="color: yellow" href="/2026/histor
 | April 20th, 2026                         | Poster-only submission deadline             |
 | May 1st 2026                         | Poster-only acceptance notification to authors|
 | Until June 28, 2026                  | Early bird registration                |
-| June 29 – July 31, 2026              | On-time bird registration              |
-| August 1 – August 12, 2026           | Late bird registration                 |
+| June 29 – ~~July 31~~ <span style="color: firebrick;">**August 12**</span>, 2026 | On-time bird registration – <span style="color: firebrick;">**Extended!**</span> |
+| <span style="color: #999;">~~August 1 – August 12, 2026~~</span> | <span style="color: #999;">~~Late bird registration~~</span> |
 | **Mon, August 31 – Fri, September 4** | TQC 2026                  |
 {{% /home-keydate-table %}}
 

--- a/content/2026/registration.md
+++ b/content/2026/registration.md
@@ -12,6 +12,9 @@ menu:
 Registration is now open! Click [here](https://event.fourwaves.com/tqc2026/) to register.
 
 ### Summary prices for registration (before fees)
+
+<p style="text-align: center; font-size: 1.2rem;"><strong>✨ Good news! The On-time bird fee has been extended until <span style="color: firebrick;">August 12</span>! ✨</strong></p>
+
 <br>
 
 <table style="border-collapse: collapse; width: 100%;text-align: center;">
@@ -19,8 +22,8 @@ Registration is now open! Click [here](https://event.fourwaves.com/tqc2026/) to 
     <tr>
       <th style="border: none; width: 15%; white-space: nowrap;"></th> 
       <th style="border: 2px solid black; padding: 8px;">Early bird (Until June 28)</th>
-      <th style="border: 2px solid black; padding: 8px;">On-time bird (June 29-July 31)</th>
-      <th style="border: 2px solid black; padding: 8px;">Late bird (August 1-August 12)</th>
+      <th style="border: 2px solid black; padding: 8px;">On-time bird (June 29-<s style="color: #999;">July 31</s> <span style="color: firebrick;">August 12</span>)</th>
+      <th style="border: 2px solid black; padding: 8px; color: #999;"><s>Late bird (August 1-August 12)</s></th>
     </tr>
   </thead>
   <tbody>
@@ -28,22 +31,24 @@ Registration is now open! Click [here](https://event.fourwaves.com/tqc2026/) to 
       <td style="border: 2px solid black; padding: 8px;"><strong>Student & Postdocs</strong></td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 475+ fees*</td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 775 + fees*</td>
-      <td style="border: 2px solid black; padding: 8px;"> CAD $ 1 300 + fees*</td>
+      <td style="border: 2px solid black; padding: 8px; color: #999;"><s>CAD $ 1 300 + fees*</s></td>
     </tr>
     <tr style="border: 2px solid black;">
       <td style="border: 2px solid black; padding: 8px;"><strong>Faculty & Staff</strong></td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 725 + fees*</td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 975 + fees*</td>
-      <td style="border: 2px solid black; padding: 8px;"> CAD $ 1 600 + fees*</td>
+      <td style="border: 2px solid black; padding: 8px; color: #999;"><s>CAD $ 1 600 + fees*</s></td>
     </tr>
     <tr style="border: 2px solid black;">
       <td style="border: 2px solid black; padding: 8px;"><strong>Industry</strong></td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 1 200 + fees*</td>
       <td style="border: 2px solid black; padding: 8px;"> CAD $ 1 500 + fees*</td>
-      <td style="border: 2px solid black; padding: 8px;"> CAD $ 2 000 + fees*</td>
+      <td style="border: 2px solid black; padding: 8px; color: #999;"><s>CAD $ 2 000 + fees*</s></td>
     </tr>
   </tbody>
 </table>
+
+<p style="text-align: center; font-size: 1.1rem;"><strong>Registration deadline is <span style="color: firebrick;">August 12</span>.</strong></p>
 
 
 **\*Fees include:** 


### PR DESCRIPTION
Applies the changes from the annotated PDF in #113.

## Registration page (`content/2026/registration.md`)

- Added the banner above the price table: **✨ Good news! The On-time bird fee has been extended until August 12! ✨**
- On-time bird column header now reads `On-time bird (June 29-~~July 31~~ August 12)` — July 31 struck through but kept visible, August 12 highlighted ("barrer, ne pas le remplacer" / "couleur différente").
- The entire Late bird column (header and all three prices) is struck through and greyed out rather than deleted ("barrer, ne pas effacer").
- Added under the table: **Registration deadline is August 12.**

## Home page Key Dates (`content/2026/_index.md`)

- On-time bird row: `June 29 – ~~July 31~~ August 12, 2026` / `On-time bird registration – Extended!`
- Late bird row struck through and greyed out.

## Note for reviewers

Striking the Late bird row on the **Key Dates** table was not literally marked in the PDF — only the registration page's Late bird column was. Leaving it live would have the home page advertising a tier that the registration page shows as cancelled, so the two were made consistent. Easy to revert if the Key Dates row was meant to stay.

Also ignores the local `.claude` directory and `__pycache__`.

Verified with a local `hugo` build (exit 0) and headless screenshots of both pages.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
