### PR TITLE
Add talk presentation guidelines to answer issue #118

### DIFF
--- a/content/2026/accepted-papers.md
+++ b/content/2026/accepted-papers.md
@@ -12,6 +12,35 @@ menu:
 
 ---
 
+<div style="background: var(--base); border: 1px solid var(--darken-2); border-radius: 1rem; padding: 2rem 2.5rem; margin-bottom: 2rem; box-shadow: 0 2px 8px var(--darken-1);">
+
+### Presentation Guidelines
+
+**Time Allocation**
+
+Each presentation slot is **30 minutes** total: maximum **25 minutes** for the presentation, followed by **5 minutes** for questions and discussion. As a general guideline, we recommend the one-slide-per-minute rule, which gives roughly 25 slides.
+
+**Slide Format and Submission**
+
+All speakers must submit their presentation in **PDF format by 21:00 (9:00 PM) the evening before** their presentation, to this address: {{< button-link label="talks_tqc2026@usherbrooke.ca" url="mailto:talks_tqc2026@usherbrooke.ca" icon="email" >}}
+
+Please use the following naming convention: `<title_Session#TrackA/B/C>.pdf` — for example, `Title_Session13TrackB.pdf`
+
+The session chair will use this PDF for the presentation. We strongly encourage all speakers to present from the submitted PDF.
+
+Speakers who wish to present using another format (PowerPoint, HTML, etc.) or their own laptop may do so, provided that their setup is tested in advance with the conference technician.
+
+To arrange this test, please bring your laptop or USB drive to your assigned room during a break **at least 30 minutes before** the session or group of sessions begins. If the setup cannot be made operational within one minute, the submitted PDF version will be used instead. If the setup is successful, any time required for switching or configuring equipment will count toward the speaker's 25-minute presentation time.
+
+**Important**
+
+- A PDF version of your presentation is mandatory, even if you plan to present using a different format or your own device. It will serve as the backup version in case of technical difficulties.
+- Presentations using personal equipment will only be permitted if the setup has been tested with the technician beforehand.
+- Speakers who arrive at the session without completing the required test will be asked to present using the PDF version on file.
+
+For questions regarding these presentation guidelines, you may write to [talks_tqc2026@usherbrooke.ca](mailto:talks_tqc2026@usherbrooke.ca).
+
+</div>
 
 ## List of Accepted Contributed Talks
 (in order of submission)


### PR DESCRIPTION
Closes #118.

The Accepted Papers page now has two sections, mirroring Accepted Posters:

1. **Presentation Guidelines** — Jérémie's guidelines transcribed directly onto the page, no PDF, inside the same callout box the posters page uses.
2. **List of Accepted Contributed Talks** — unchanged.

The guidelines keep everything from the file: the 30-minute slot (25 for the talk, 5 for questions, roughly one slide per minute), the PDF due at 21:00 the evening before to `talks_tqc2026@usherbrooke.ca` with the `<title_Session#TrackA/B/C>.pdf` naming convention, the session chair presenting from that PDF, and the technician test required to present from another format or one's own laptop — including the 30-minutes-before window, the one-minute rule and the fact that setup time counts against the 25 minutes.

Two things worth a look when you review the deploy preview:

- The submission address renders as a primary button, the site's usual treatment for emails on the registration and call pages. The `mailto:` link is correct, but the theme uppercases button labels, so it reads `TALKS_TQC2026@USHERBROOKE.CA`. The posters box has no button; happy to swap it for a plain lowercase link if that reads better here.
- The sub-headings are bold labels rather than `h4`. This page is a `list_with_header`, and the `text_page` heading sizes do not reach its `.content` section, so an `h4` renders indistinguishably from a paragraph.

Checked against a production build: the box renders as real HTML rather than escaped text, the build warnings are identical to those on `main`, and the only outputs that differ are this page and the two RSS feeds that embed it. The talks list below is byte-identical.
