### PR TITLE
Link LIPIcs proceedings versions from the accepted papers list

### DIFF
--- a/content/2026/accepted-papers.md
+++ b/content/2026/accepted-papers.md
@@ -44,5 +44,8 @@ For questions regarding these presentation guidelines, you may write to [talks_t
 
 ## List of Accepted Contributed Talks
 (in order of submission)
+
+Papers whose authors opted in are published in the conference proceedings, [LIPIcs Volume 389](https://drops.dagstuhl.de/entities/volume/LIPIcs-volume-389); those entries carry a `[proceedings]` link below.
+
 {{< papers-accepted year=2026 >}}
 {{< /papers-accepted >}}

--- a/data/proceedings-2026.yml
+++ b/data/proceedings-2026.yml
@@ -1,0 +1,11 @@
+# TQC 2026 proceedings: LIPIcs, Volume 389
+# https://drops.dagstuhl.de/entities/volume/LIPIcs-volume-389
+# Keys are HotCRP submission ids (pid), as strings; values are DOIs.
+"108": 10.4230/LIPIcs.TQC.2026.1
+"134": 10.4230/LIPIcs.TQC.2026.2
+"176": 10.4230/LIPIcs.TQC.2026.3
+"224": 10.4230/LIPIcs.TQC.2026.4
+"258": 10.4230/LIPIcs.TQC.2026.5
+"296": 10.4230/LIPIcs.TQC.2026.6
+"362": 10.4230/LIPIcs.TQC.2026.7
+"364": 10.4230/LIPIcs.TQC.2026.8

--- a/themes/devfest-theme-hugo/assets/style/pages/_papers.scss
+++ b/themes/devfest-theme-hugo/assets/style/pages/_papers.scss
@@ -46,6 +46,11 @@
       padding-left: var(--space-1);
     }
 
+    .paper-proceedings {
+      display: inline;
+      padding-left: var(--space-1);
+    }
+
 
   }
 }

--- a/themes/devfest-theme-hugo/layouts/partials/paper.html
+++ b/themes/devfest-theme-hugo/layouts/partials/paper.html
@@ -52,6 +52,15 @@ CurrentYear: {{ $currentYear }}
 	</div>
 	{{ end }}
 
+	{{/* proceedings (LIPIcs) version, if this paper is in the volume for this year */}}
+	{{ $procKey := printf "proceedings-%s" $currentYear }}
+	{{ $proceedings := index site.Data $procKey | default dict }}
+	{{ with index $proceedings (printf "%.0f" .pid) }}
+	<div class="paper-proceedings">
+		<a href="https://doi.org/{{ . }}" target="_blank">[proceedings]</a>
+	</div>
+	{{ end }}
+
   {{ $dataKey := printf "youtube-%s" (string $currentYear) }}
   {{ $youtube := index site.Data $dataKey | default slice }}
   <div class="paper-youtubeid">


### PR DESCRIPTION
The TQC 2026 proceedings are published as [LIPIcs Volume 389](https://drops.dagstuhl.de/entities/volume/LIPIcs-volume-389) (published 2026-08-25, ISBN 978-3-95977-439-0). Eight of the 87 accepted contributed talks opted in. Until now nothing on the site pointed at the published, citable version.

Those eight entries now carry a `[proceedings]` link resolving through `doi.org`, next to the existing `[abstract]` / `[extended abstract]` / `[slides]` links, and the page intro points at the volume as a whole.

### Matching

Papers were matched to HotCRP submission ids by normalised title. Seven titles match exactly; pid 224 differs only by "Speedups **for**" (site) vs "Speedups **in**" (LIPIcs), and its seven-author list matches verbatim.

| pid | DOI | Title |
|---|---|---|
| 108 | `10.4230/LIPIcs.TQC.2026.1` | A Sharp Computational Phase Transition for the Partition Function of the Transverse-Field Ising Model |
| 134 | `10.4230/LIPIcs.TQC.2026.2` | Characterization of Permutation Gates in the Third Level of the Clifford Hierarchy |
| 176 | `10.4230/LIPIcs.TQC.2026.3` | Quantum Search with Generalized Wildcards |
| 224 | `10.4230/LIPIcs.TQC.2026.4` | Provable Speedups for Convex Optimization via Quantum Dynamics |
| 258 | `10.4230/LIPIcs.TQC.2026.5` | Quantum Merlin-Arthur with an Internally Separable Proof |
| 296 | `10.4230/LIPIcs.TQC.2026.6` | Limitations of Decoded Quantum Interferometry for MaxCut |
| 362 | `10.4230/LIPIcs.TQC.2026.7` | On the Complexity of the Circuit Width Problem |
| 364 | `10.4230/LIPIcs.TQC.2026.8` | Quantum Speedups for Sampling and Non-convex Optimization with Stochastic Oracles |

### Changes

- **`data/proceedings-2026.yml`** (new) — the pid → DOI mapping. Kept out of `data/accepted-papers-2026.json` on purpose: that file is regenerated from HotCRP exports by `scripts/sanitize_hotcrp_json.py`, which would drop an added field. This follows the override pattern of `data/presenters-overrides-2026.yml` and the string-pid key convention of `data/presenters-2026.yml`.
- **`layouts/partials/paper.html`** — year-keyed lookup (`proceedings-<year>`), same shape as the existing `youtube-<year>` lookup just below it. `| default dict` means years and poster pages without a mapping file render nothing.
- **`assets/style/pages/_papers.scss`** — `.paper-proceedings`, identical to `.paper-extended-abstract`.
- **`content/2026/accepted-papers.md`** — one sentence linking the volume.

### Verification

`hugo --gc --minify` builds clean (only pre-existing schedule warnings). In the output:

- `/2026/accepted-papers/` has exactly 8 `doi.org` links, on list items 108, 134, 176, 224, 258, 296, 362 and 364 — each paired with the right DOI.
- pids 258 and 364 show `[extended abstract]` and `[proceedings]` side by side.
- 8 links across 6 `/2026/sessions/` pages, which reuse the same partial.
- `/2024/accepted-papers/` and `/2026/accepted-posters/`: 0 occurrences, unchanged.
- Both spot-checked DOIs resolve (302 → the Dagstuhl document page).

If more articles are added to the volume later, the only edit needed is another line in `data/proceedings-2026.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JPKPpPuURL5GgMPxXK4B9